### PR TITLE
Rimuovere versioni obsolete per evitare confusione

### DIFF
--- a/doc/01_Raccomandazioni TLS/04_tls.rst
+++ b/doc/01_Raccomandazioni TLS/04_tls.rst
@@ -8,8 +8,6 @@ Ad oggi sono disponibili le seguenti versioni TLS:
 
 - TLS 1.3    (pubblicato nel 2018)    
 - TLS 1.2    (pubblicato nel 2008)  
-- TLS 1.1    (pubblicato nel 2006)
-- TLS 1.0    (pubblicato nel 1999)
 
 TLS 1.0 e 1.1 sono protocolli obsoleti che non supportano i moderni 
 algoritmi crittografici e risultano vulnerabili ad attacchi [1]_. 


### PR DESCRIPTION
## Questa PR

Per non confondere il lettore, poiché le versioni obsolete di TLS sono indicate nel seguito, lascerei solo quelle raccomandate.