### PR TITLE
[WIP] Chiarimento sulla frequenza di validazione dei certificati TLS.

### DIFF
--- a/doc/00_Linee guida sicurezza API/07_construzione-trust/02_emissione_distribuzione_certificati_digitali/01_certificati_eIDAS.rst
+++ b/doc/00_Linee guida sicurezza API/07_construzione-trust/02_emissione_distribuzione_certificati_digitali/01_certificati_eIDAS.rst
@@ -27,7 +27,8 @@ dei certificati qualificati:
    * - **[SIC_API_06]** 
      - I soggetti che rendono disponibili API DEVONO verificare la 
        validità dei certificati qualificati emessi da una CAQ, compresa 
-       l’eventuale revoca degli stessi, per ogni invocazione da parte 
+       l’eventuale revoca degli stessi, ogni volta che i certificati
+       vengono utilizzati (ad esempio per stabilire una sessione TLS) da parte 
        di soggetti delle stesse API per cui è abilitato l’accesso.
 
    


### PR DESCRIPTION
## Questa PR

** importante ** ci sono diversi punti dove viene usato il termine `invocazione`. Andrebbe chiarito in ognuno di essi.

Prova a chiarire la frequenza di validazione dei certificati.
Nel contesto TLS infatti, l'invocazione consiste nell'apertura della sessione.



## Note

Poiché TLS incapsula il protocollo superiore, non ha visibilità su quanti messaggi
passano all'interno del canale (eg. SMTP, HTTP/1.1, ...).

Nota: anche se questa PR è migliorativa, il tema della frequenza di validazione non è banale soprattutto per i servizi ad
alto traffico poiché:
- eIDAS ha uno SLA di 24 ore per l'aggiornamento delle CRL
- ulteriori considerazioni che suggeriscono di demandare la frequenza di validazione ad Erogatore e Fruitore in base alla tipologia del servizio utilizzato ed ai volumi di traffico si trovano al §4.9 di https://www.openbankingeurope.eu/media/1940/obe-eidas-qualified-certificates-faq.pdf (eg. potrebbe essere anche ogni 5 minuti se il servizio lo permette).

cc: @berez23 ti torna questa formulazione?